### PR TITLE
Support enums for non-enum types

### DIFF
--- a/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/EnumMarshalInfo.java
+++ b/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/EnumMarshalInfo.java
@@ -1,41 +1,29 @@
-/*
- * Copyright 2014 Guidewire Software, Inc.
- */
-
 package gw.internal.xml.ws.server.marshal;
 
 import gw.internal.schema.gw.xsd.w3c.xmlschema.Enumeration;
 import gw.internal.schema.gw.xsd.w3c.xmlschema.Restriction;
 import gw.internal.schema.gw.xsd.w3c.xmlschema.SimpleType;
 import gw.internal.schema.gw.xsd.w3c.xmlschema.types.complex.LocalElement;
-import gw.internal.xml.IXmlLoggerFactory;
-import gw.internal.xml.config.XmlServices;
 import gw.internal.xml.ws.server.WsiServiceInfo;
 import gw.lang.reflect.IEnumConstant;
-import gw.lang.reflect.IEnumType;
+import gw.lang.reflect.IEnumData;
 import gw.lang.reflect.IEnumValue;
 import gw.lang.reflect.IType;
-import gw.lang.reflect.java.IJavaType;
-import gw.lang.reflect.java.JavaTypes;
 import gw.xml.XmlElement;
 import gw.xml.XmlSchemaAccess;
 
-import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-public class EnumMarshalInfo extends MarshalInfo {
-  private final IEnumType _type;
-  private boolean _isComponent;
+public abstract class EnumMarshalInfo extends MarshalInfo {
+  protected boolean _isComponent;
 
-  public EnumMarshalInfo(IEnumType type, boolean isComponent ) {
-    super( type );
-    _type = type;
+  public EnumMarshalInfo(IType type, boolean isComponent) {
+    super(type);
     _isComponent = isComponent;
-
   }
 
   @Override
@@ -51,12 +39,12 @@ public class EnumMarshalInfo extends MarshalInfo {
     else {
       element.setMinOccurs$( BigInteger.ZERO );
     }
-    SimpleType simpleType = createInfo.getSimpleTypeIfNeededFor(_type);
+    SimpleType simpleType = createInfo.getSimpleTypeIfNeededFor(getType());
     if (simpleType != null) {
       Restriction restriction = new Restriction();
       restriction.setBase$(XS_STRING_QNAME);
       ArrayList<Enumeration> enumerations = new ArrayList<Enumeration>();
-      for (IEnumValue value : _type.getEnumValues()) {
+      for (IEnumValue value : getEnumData().getEnumValues()) {
         Enumeration enumEL = new Enumeration();
         enumEL.setValue$(value.getCode());
         enumerations.add(enumEL);
@@ -64,53 +52,22 @@ public class EnumMarshalInfo extends MarshalInfo {
       restriction.setEnumeration$(enumerations);
       simpleType.setRestriction$(restriction);
     }
-    element.setType$( createInfo.getQName(_type) );
+    element.setType$( createInfo.getQName(getType()) );
   }
 
   @Override
   public Object unmarshal(XmlElement componentElement, UnmarshalContext context) {
-    if (_type instanceof IJavaType) { // java enums
-      try {
-        IJavaType jtype = (IJavaType) _type;
-        Class clazz = jtype.getBackingClass();
-        for (Field field : clazz.getDeclaredFields()) {
-          if (field.getName().equalsIgnoreCase(componentElement.getText())) {
-            return field.get(null);
-          }
-        }
-        throw new RuntimeException("invalid " + _type + " '" + componentElement.getText() + "");
-      } catch (Throwable e) {
-        XmlServices.getLogger(IXmlLoggerFactory.Category.XmlUnMarshal).error("Exception on " + _type + " '" + componentElement.getText() + "", e);
-      }
-    }
-    IEnumValue value = _type.getEnumValue(componentElement.getText());
+    IEnumValue value = getEnumData().getEnumValue(componentElement.getText());
     if (value == null) {
-      throw new RuntimeException("invalid " + _type + " '" + componentElement.getText() + "");
+      throw new RuntimeException("invalid " + getType() + " '" + componentElement.getText() + "");
     }
     return value;
   }
 
   @Override
   public void marshal(XmlElement returnEl, IType type, Object obj, MarshalContext context) {
-    if (_type instanceof IJavaType) { // java enums
-      try {
-        IJavaType jtype = (IJavaType) _type;
-        Class clazz = jtype.getBackingClass();
-        for (Field field : clazz.getDeclaredFields()) {
-          if (field.get(null).equals(obj)) {
-            returnEl.setText(field.getName());
-            return;
-          }
-        }
-        XmlServices.getLogger(IXmlLoggerFactory.Category.XmlMarshal).error("Couldn't find " + _type + ": " + obj);
-      } catch (Throwable e) {
-        XmlServices.getLogger(IXmlLoggerFactory.Category.XmlUnMarshal).error("Exception on " + _type + ": " + obj, e);
-      }
-    }
-    else { // typelists, gosu enums
-      returnEl.setText(((IEnumConstant)obj).getCode());
-    }
+    returnEl.setText(((IEnumConstant)obj).getCode());
   }
 
-
+  protected abstract IEnumData getEnumData();
 }

--- a/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/EnumTypeMarshalInfo.java
+++ b/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/EnumTypeMarshalInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013 Guidewire Software, Inc.
+ */
+
+package gw.internal.xml.ws.server.marshal;
+
+import gw.internal.xml.IXmlLoggerFactory;
+import gw.internal.xml.config.XmlServices;
+import gw.lang.reflect.IEnumData;
+import gw.lang.reflect.IEnumType;
+import gw.lang.reflect.IType;
+import gw.lang.reflect.java.IJavaType;
+import gw.xml.XmlElement;
+
+import java.lang.reflect.Field;
+
+public class EnumTypeMarshalInfo extends EnumMarshalInfo {
+
+  public EnumTypeMarshalInfo(IEnumType type, boolean isComponent) {
+    super( type, isComponent);
+  }
+
+  @Override
+  protected IEnumData getEnumData() {
+    return (IEnumType) getType();
+  }
+
+  @Override
+  public Object unmarshal(XmlElement componentElement, UnmarshalContext context) {
+    if (getType() instanceof IJavaType) { // java enums
+      try {
+        IJavaType jtype = (IJavaType) getType();
+        Class clazz = jtype.getBackingClass();
+        for (Field field : clazz.getDeclaredFields()) {
+          if (field.getName().equalsIgnoreCase(componentElement.getText())) {
+            return field.get(null);
+          }
+        }
+        throw new RuntimeException("invalid " + getType() + " '" + componentElement.getText() + "");
+      } catch (Throwable e) {
+        XmlServices.getLogger(IXmlLoggerFactory.Category.XmlUnMarshal).error("Exception on " + getType() + " '" + componentElement.getText() + "", e);
+      }
+    }
+    return super.unmarshal(componentElement, context);
+  }
+
+  @Override
+  public void marshal(XmlElement returnEl, IType type, Object obj, MarshalContext context) {
+    if (getType() instanceof IJavaType) { // java enums
+      try {
+        IJavaType jtype = (IJavaType) getType();
+        Class clazz = jtype.getBackingClass();
+        for (Field field : clazz.getDeclaredFields()) {
+          if (field.get(null).equals(obj)) {
+            returnEl.setText(field.getName());
+            return;
+          }
+        }
+        XmlServices.getLogger(IXmlLoggerFactory.Category.XmlMarshal).error("Couldn't find " + getType() + ": " + obj);
+      } catch (Throwable e) {
+        XmlServices.getLogger(IXmlLoggerFactory.Category.XmlUnMarshal).error("Exception on " + getType() + ": " + obj, e);
+      }
+    }
+    else { // typelists, gosu enums
+      super.marshal(returnEl, type, obj, context);
+    }
+  }
+}

--- a/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/MarshalInfoFactory.java
+++ b/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/MarshalInfoFactory.java
@@ -1,0 +1,8 @@
+package gw.internal.xml.ws.server.marshal;
+
+import gw.internal.xml.ws.server.WsiServiceInfo;
+import gw.lang.reflect.IType;
+
+public interface MarshalInfoFactory {
+  MarshalInfo createMarshalInfoForType(IType type, boolean component, WsiServiceInfo serviceInfo);
+}

--- a/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/XmlMarshaller.java
+++ b/gosu-webservices/src/main/java/gw/internal/xml/ws/server/marshal/XmlMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Guidewire Software, Inc.
+ * Copyright 2013 Guidewire Software, Inc.
  */
 
 package gw.internal.xml.ws.server.marshal;
@@ -24,9 +24,12 @@ import gw.xml.XmlElement;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Comparator;
+import java.util.HashMap;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+
+import static java.lang.String.format;
 
 /**
  * This is what the marshaller does, marshal, unmarshal, valid types, create schemas</desc>
@@ -58,8 +61,18 @@ public class XmlMarshaller {
     }
   };
 
+  private static final HashMap<IType, MarshalInfoFactory> _customMarshalInfoFactories =
+          new HashMap<IType, MarshalInfoFactory>();
+
   private XmlMarshaller() {
     
+  }
+
+  public static void addCustomMarshallerFactory(IType type, MarshalInfoFactory factory) {
+    MarshalInfoFactory prev = _customMarshalInfoFactories.put(type, factory);
+    if (prev != null && !prev.equals(factory)) {
+      throw new IllegalArgumentException(format("Custom marshaller factory already registered for type %s", type));
+    }
   }
 
   public static String createTargetNamespace( String prefix, IType type ) {
@@ -108,8 +121,12 @@ public class XmlMarshaller {
     if (type == null) {
       return null;
     }
+    MarshalInfoFactory factory = _customMarshalInfoFactories.get(type);
+    if (factory != null) {
+      return factory.createMarshalInfoForType(type, isComponent, serviceInfo);
+    }
     if ( type.isEnum() && serviceInfo != null && ! serviceInfo.getExposeEnumAsStringTypes().contains( type ) ) {
-       return new EnumMarshalInfo((IEnumType)type, isComponent); 
+       return new EnumTypeMarshalInfo((IEnumType)type, isComponent);
     }
     Pair<QName, XmlSimpleValueFactory> pair = XmlSchemaTypeToGosuTypeMappings.gosuToSchemaIfValid( type );
     if ( pair != null ) {


### PR DESCRIPTION
Typelists are no longer enum types, but they need to be treated as enums
in webservices. This change allows typelists to be "marshalled" as
enums, even though they aren't technically enum types.
